### PR TITLE
Add ability to ignore repositories in harbor-vulnerabilities-exporter

### DIFF
--- a/charts/harbor-vulnerabilities-exporter/Chart.yaml
+++ b/charts/harbor-vulnerabilities-exporter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: harbor-vulnerabilities-exporter
 description: A Helm chart for showing vulnerabilities information in images stored in Harbor
-version: 1.0.1
+version: 1.0.2
 sources:
   - https://github.com/NCCloud/harbor-vulnerabilities-exporter
 maintainers:

--- a/charts/harbor-vulnerabilities-exporter/templates/deployment.yaml
+++ b/charts/harbor-vulnerabilities-exporter/templates/deployment.yaml
@@ -32,4 +32,4 @@ spec:
             - name: THREADS
               value: "{{ .Values.threadCount }}"
             - name: IGNORE_REPOSITORIES
-              value: '[{{ .Values.ignoreRepositories }}]'
+              value: '{{ .Values.ignoreRepositories }}'

--- a/charts/harbor-vulnerabilities-exporter/templates/deployment.yaml
+++ b/charts/harbor-vulnerabilities-exporter/templates/deployment.yaml
@@ -31,3 +31,5 @@ spec:
               value: "{{ .Values.exporterPort }}"
             - name: THREADS
               value: "{{ .Values.threadCount }}"
+            - name: IGNORE_REPOSITORIES
+              value: '[{{ .Values.ignoreRepositories }}]'

--- a/charts/harbor-vulnerabilities-exporter/values.yaml
+++ b/charts/harbor-vulnerabilities-exporter/values.yaml
@@ -5,6 +5,9 @@ exporterPort: 8000
 # -- number of threads for exporter script to call Harbor API
 threadCount: 5
 
+# -- list of project/repositories to ignore (won't create a metric in prometheus), for example: '"project/repo1", "project/repo2"'
+ignoreRepositories: ''
+
 # -- script won't use credentials if values are empty read-only user should be enough
 harborUsername: ''
 harborPassword: ''

--- a/charts/harbor-vulnerabilities-exporter/values.yaml
+++ b/charts/harbor-vulnerabilities-exporter/values.yaml
@@ -5,7 +5,7 @@ exporterPort: 8000
 # -- number of threads for exporter script to call Harbor API
 threadCount: 5
 
-# -- list of project/repositories to ignore (won't create a metric in prometheus), for example: '"project/repo1", "project/repo2"'
+# -- comma separated list of project/repositories to ignore (won't create a metric in prometheus), for example: 'project/repo1,project/repo2'
 ignoreRepositories: ''
 
 # -- script won't use credentials if values are empty read-only user should be enough


### PR DESCRIPTION
Adding `IGNORE_REPOSITORIES` env variable to deployment template and `ignoreRepositories` to values.