### PR TITLE
Fix helm install step in release workflow

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -12,9 +12,9 @@ jobs:
         with:
           fetch-depth: 0
       - name: Setup Helm
-        uses: azure/setup-helm@v3
+        uses: azure/setup-helm@v4.2.0
       - name: Setup Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: 3.8
       - name: Setup chart-testing

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Configure Git
@@ -35,10 +35,10 @@ jobs:
             git push
           fi
       - name: Install Helm
-        uses: azure/setup-helm@v3
+        uses: azure/setup-helm@v4.2.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Release Chart
-        uses: helm/chart-releaser-action@v1.5.0
+        uses: helm/chart-releaser-action@v1.6.0
         env:
           CR_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -36,8 +36,6 @@ jobs:
           fi
       - name: Install Helm
         uses: azure/setup-helm@v4.2.0
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Release Chart
         uses: helm/chart-releaser-action@v1.6.0
         env:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -36,6 +36,8 @@ jobs:
           fi
       - name: Install Helm
         uses: azure/setup-helm@v3
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Release Chart
         uses: helm/chart-releaser-action@v1.5.0
         env:

--- a/charts/harbor-vulnerabilities-exporter/Chart.yaml
+++ b/charts/harbor-vulnerabilities-exporter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: harbor-vulnerabilities-exporter
 description: A Helm chart for showing vulnerabilities information in images stored in Harbor
-version: 1.0.3
+version: 1.0.4
 sources:
   - https://github.com/NCCloud/harbor-vulnerabilities-exporter
 maintainers:


### PR DESCRIPTION
![image](https://github.com/NCCloud/charts/assets/40362174/a4726162-31ce-4676-8fe9-4f75062e24b1)

looks like it has been fixed in the newest version of setup-helm gh action:

![image](https://github.com/NCCloud/charts/assets/40362174/a93937bb-1420-4718-98b5-02fc46bfd30b)
