### PR TITLE
Tabby Operator v0.0.43

### DIFF
--- a/charts/tabby-operator/Chart.yaml
+++ b/charts/tabby-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: tabby-operator
 description: A Helm chart for Kubernetes tabby cni operator
-version: 0.0.42
+version: 0.0.43
 sources:
   - https://github.com/NCCloud/tabby-cni
 maintainers:

--- a/charts/tabby-operator/crds/cloud.spaceship.com_networkattachments.yaml
+++ b/charts/tabby-operator/crds/cloud.spaceship.com_networkattachments.yaml
@@ -3,8 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.10.0
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.15.0
   name: networkattachments.cloud.spaceship.com
 spec:
   group: cloud.spaceship.com
@@ -21,14 +20,19 @@ spec:
         description: Network is the Schema for the networks API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -61,7 +65,7 @@ spec:
                   type: object
                 type: array
               ipMasq:
-                description: Masquerade overcloud traffic
+                description: Masquerade virtual machine traffic
                 properties:
                   bridge:
                     type: string
@@ -76,6 +80,7 @@ spec:
                   source:
                     type: string
                 required:
+                - bridge
                 - enabled
                 - source
                 type: object
@@ -83,58 +88,60 @@ spec:
                 type: string
               nodeSelectors:
                 items:
-                  description: A label selector is a label query over a set of resources.
-                    The result of matchLabels and matchExpressions are ANDed. An empty
-                    label selector matches all objects. A null label selector matches
-                    no objects.
+                  description: |-
+                    A label selector is a label query over a set of resources. The result of matchLabels and
+                    matchExpressions are ANDed. An empty label selector matches all objects. A null
+                    label selector matches no objects.
                   properties:
                     matchExpressions:
                       description: matchExpressions is a list of label selector requirements.
                         The requirements are ANDed.
                       items:
-                        description: A label selector requirement is a selector that
-                          contains values, a key, and an operator that relates the
-                          key and values.
+                        description: |-
+                          A label selector requirement is a selector that contains values, a key, and an operator that
+                          relates the key and values.
                         properties:
                           key:
                             description: key is the label key that the selector applies
                               to.
                             type: string
                           operator:
-                            description: operator represents a key's relationship
-                              to a set of values. Valid operators are In, NotIn, Exists
-                              and DoesNotExist.
+                            description: |-
+                              operator represents a key's relationship to a set of values.
+                              Valid operators are In, NotIn, Exists and DoesNotExist.
                             type: string
                           values:
-                            description: values is an array of string values. If the
-                              operator is In or NotIn, the values array must be non-empty.
-                              If the operator is Exists or DoesNotExist, the values
-                              array must be empty. This array is replaced during a
-                              strategic merge patch.
+                            description: |-
+                              values is an array of string values. If the operator is In or NotIn,
+                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                              the values array must be empty. This array is replaced during a strategic
+                              merge patch.
                             items:
                               type: string
                             type: array
+                            x-kubernetes-list-type: atomic
                         required:
                         - key
                         - operator
                         type: object
                       type: array
+                      x-kubernetes-list-type: atomic
                     matchLabels:
                       additionalProperties:
                         type: string
-                      description: matchLabels is a map of {key,value} pairs. A single
-                        {key,value} in the matchLabels map is equivalent to an element
-                        of matchExpressions, whose key field is "key", the operator
-                        is "In", and the values array contains only "value". The requirements
-                        are ANDed.
+                      description: |-
+                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                        map is equivalent to an element of matchExpressions, whose key field is "key", the
+                        operator is "In", and the values array contains only "value". The requirements are ANDed.
                       type: object
                   type: object
                   x-kubernetes-map-type: atomic
                 type: array
               routes:
                 items:
-                  description: Static routes The Via parameter could be ip address
-                    or device name.
+                  description: |-
+                    Static routes
+                    The Via parameter could be ip address or device name.
                   properties:
                     destination:
                       type: string

--- a/charts/tabby-operator/crds/cloud.spaceship.com_networks.yaml
+++ b/charts/tabby-operator/crds/cloud.spaceship.com_networks.yaml
@@ -3,8 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.10.0
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.15.0
   name: networks.cloud.spaceship.com
 spec:
   group: cloud.spaceship.com
@@ -21,14 +20,19 @@ spec:
         description: Network is the Schema for the networks API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -61,7 +65,7 @@ spec:
                   type: object
                 type: array
               ipMasq:
-                description: Masquerade overcloud traffic
+                description: Masquerade virtual machine traffic
                 properties:
                   bridge:
                     type: string
@@ -76,63 +80,66 @@ spec:
                   source:
                     type: string
                 required:
+                - bridge
                 - enabled
                 - source
                 type: object
               nodeSelectors:
                 items:
-                  description: A label selector is a label query over a set of resources.
-                    The result of matchLabels and matchExpressions are ANDed. An empty
-                    label selector matches all objects. A null label selector matches
-                    no objects.
+                  description: |-
+                    A label selector is a label query over a set of resources. The result of matchLabels and
+                    matchExpressions are ANDed. An empty label selector matches all objects. A null
+                    label selector matches no objects.
                   properties:
                     matchExpressions:
                       description: matchExpressions is a list of label selector requirements.
                         The requirements are ANDed.
                       items:
-                        description: A label selector requirement is a selector that
-                          contains values, a key, and an operator that relates the
-                          key and values.
+                        description: |-
+                          A label selector requirement is a selector that contains values, a key, and an operator that
+                          relates the key and values.
                         properties:
                           key:
                             description: key is the label key that the selector applies
                               to.
                             type: string
                           operator:
-                            description: operator represents a key's relationship
-                              to a set of values. Valid operators are In, NotIn, Exists
-                              and DoesNotExist.
+                            description: |-
+                              operator represents a key's relationship to a set of values.
+                              Valid operators are In, NotIn, Exists and DoesNotExist.
                             type: string
                           values:
-                            description: values is an array of string values. If the
-                              operator is In or NotIn, the values array must be non-empty.
-                              If the operator is Exists or DoesNotExist, the values
-                              array must be empty. This array is replaced during a
-                              strategic merge patch.
+                            description: |-
+                              values is an array of string values. If the operator is In or NotIn,
+                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                              the values array must be empty. This array is replaced during a strategic
+                              merge patch.
                             items:
                               type: string
                             type: array
+                            x-kubernetes-list-type: atomic
                         required:
                         - key
                         - operator
                         type: object
                       type: array
+                      x-kubernetes-list-type: atomic
                     matchLabels:
                       additionalProperties:
                         type: string
-                      description: matchLabels is a map of {key,value} pairs. A single
-                        {key,value} in the matchLabels map is equivalent to an element
-                        of matchExpressions, whose key field is "key", the operator
-                        is "In", and the values array contains only "value". The requirements
-                        are ANDed.
+                      description: |-
+                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                        map is equivalent to an element of matchExpressions, whose key field is "key", the
+                        operator is "In", and the values array contains only "value". The requirements are ANDed.
                       type: object
                   type: object
                   x-kubernetes-map-type: atomic
                 type: array
               routes:
                 items:
-                  description: Static routes The Via parameter could be ip address
-                    or device name.
+                  description: |-
+                    Static routes
+                    The Via parameter could be ip address or device name.
                   properties:
                     destination:
                       type: string

--- a/charts/tabby-operator/templates/daemonset.yaml
+++ b/charts/tabby-operator/templates/daemonset.yaml
@@ -43,6 +43,9 @@ spec:
           - -health-probe-bind-address=:8002
           command:
           - /manager
+          env:
+          - name: WATCH_KUBEVIRT_MIGRATION
+            value: {{ default "false" .Values.operatorConfig.watchKubevirtMigration | quote }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy | default "IfNotPresent" }}
           livenessProbe:

--- a/charts/tabby-operator/templates/role.yaml
+++ b/charts/tabby-operator/templates/role.yaml
@@ -70,6 +70,7 @@ rules:
   - get
   - patch
   - update
+{{- if .Values.operatorConfig.watchKubevirtMigration }}
 - apiGroups:
   - kubevirt.io
   resources:
@@ -78,4 +79,5 @@ rules:
   - get
   - list
   - watch
+{{- end }}
 {{- end }}

--- a/charts/tabby-operator/templates/role.yaml
+++ b/charts/tabby-operator/templates/role.yaml
@@ -11,6 +11,14 @@ metadata:
   {{- end }}
 rules:
 - apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - cloud.spaceship.com
   resources:
   - networkattachments
@@ -63,9 +71,9 @@ rules:
   - patch
   - update
 - apiGroups:
-  - ""
+  - kubevirt.io
   resources:
-  - nodes
+  - virtualmachineinstances
   verbs:
   - get
   - list

--- a/charts/tabby-operator/values.yaml
+++ b/charts/tabby-operator/values.yaml
@@ -65,5 +65,6 @@ affinity:
           - linux
 
 operatorConfig:
-  # -- whether to enable the controller that watches the completion of KubeVirt VM migrations and sends a GARP request
+  # -- whether to enable the controller that watches the completion of KubeVirt VM migrations and sends a GARP request.
+  # This also dynamically configures required RBAC permissions
   watchKubevirtMigration: false

--- a/charts/tabby-operator/values.yaml
+++ b/charts/tabby-operator/values.yaml
@@ -63,3 +63,7 @@ affinity:
           operator: In
           values:
           - linux
+
+operatorConfig:
+  # -- whether to enable the controller that watches the completion of KubeVirt VM migrations and sends a GARP request
+  watchKubevirtMigration: false


### PR DESCRIPTION
# What does this change do?
This version of the Tabby Operator Helm chart supports [tabby-cni](https://github.com/NCCloud/tabby-cni) `0.0.43`.

This patch does the following changes:
- Update CRDs
- Introduce the `operatorConfig` section in the values file. By default, `watchKubevirtMigration` is disabled.
- Dynamically update `ClusterRole` with permissions for watching `virtualmachineinstances.kubevirt.io` if `operatorConfig.watchKubevirtMigration` is enabled.