### PR TITLE
Metadata Reflector 0.2.0

### DIFF
--- a/charts/metadata-reflector/Chart.yaml
+++ b/charts/metadata-reflector/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: Metadata Reflector
 name: metadata-reflector
-version: 0.1.2
-appVersion: 0.2.1
+version: 0.2.0
+appVersion: 0.3.0
 sources:
   - https://github.com/NCCloud/metadata-reflector
 maintainers:

--- a/charts/metadata-reflector/README.md
+++ b/charts/metadata-reflector/README.md
@@ -1,6 +1,6 @@
 # metadata-reflector
 
-![Version: 0.1.2](https://img.shields.io/badge/Version-0.1.2-informational?style=flat-square) ![AppVersion: 0.2.1](https://img.shields.io/badge/AppVersion-0.2.1-informational?style=flat-square)
+![Version: 0.2.0](https://img.shields.io/badge/Version-0.2.0-informational?style=flat-square) ![AppVersion: 0.3.0](https://img.shields.io/badge/AppVersion-0.3.0-informational?style=flat-square)
 
 Metadata Reflector
 
@@ -23,6 +23,7 @@ Metadata Reflector
 | configuration.backgroundReflectionInterval | string | `"5m"` | The frequency of the background reconciliation. Set to 0 to disable |
 | configuration.gomaxprocsOverride | string | `""` | The value for GOMAXPROCS. By default, the CPU limit of the deployment. See https://pkg.go.dev/runtime#hdr-Environment_Variables |
 | configuration.gomemlimitOverride | string | `""` | The value for GOMEMLIMIT. By default, the memory limit of the deployment. See https://pkg.go.dev/runtime#hdr-Environment_Variables |
+| configuration.maxConcurrentReconciles | int | `1` |  |
 | configuration.namespaces | list | `[]` | A list of namespaces to watch |
 | configuration.resourceSelector | object | `{}` | Configure what resources will be watched by the controller. An example can be seen in `values.yaml`. At the moment, only Deployment is supported |
 | extraEnvs | list | `[]` | Extra environment variables to be passed to the controller deployment |

--- a/charts/metadata-reflector/templates/clusterrole.yaml
+++ b/charts/metadata-reflector/templates/clusterrole.yaml
@@ -15,6 +15,11 @@ rules:
       - watch
       - patch
       - update
+  - apiGroups: [""]
+    resources:
+      - events
+    verbs:
+      - create
   - apiGroups:
       - apps
     resources:

--- a/charts/metadata-reflector/templates/deployment.yaml
+++ b/charts/metadata-reflector/templates/deployment.yaml
@@ -52,7 +52,9 @@ spec:
             value: "{{ .Values.metrics.port }}"
           - name: NAMESPACES
             value: "{{ join "," .Values.configuration.namespaces }}"
-          {{- if gt .Values.replicaCount 1.0 }}
+          - name: MAX_CONCURRENT_RECONCILES
+            value: "{{ .Values.configuration.maxConcurrentReconciles }}"
+          {{- if gt (int .Values.replicaCount) 1 }}
           - name: ENABLE_LEADER_ELECTION
             value: "true"
           {{- end }}

--- a/charts/metadata-reflector/values.yaml
+++ b/charts/metadata-reflector/values.yaml
@@ -84,6 +84,7 @@ configuration:
   #     values: ["hello", "world"]
   # -- A list of namespaces to watch
   namespaces: []
+  maxConcurrentReconciles: 1
 
   # -- The value for GOMAXPROCS. By default, the CPU limit of the deployment.
   # See https://pkg.go.dev/runtime#hdr-Environment_Variables


### PR DESCRIPTION
### What does this change resolve?
- Upgrade `metadata-reflector` app to `0.3.0`
- Add a cluster role permission to create events about the leader change
- Fix leader election templating when values are provided from the `--set` flag using the Helm CLI
- Add an option to set `maxConcurrentReconciles`. Defaults to `1`