### PR TITLE
Modify the WatchtowerDown query and add a critical alert

### DIFF
--- a/charts/watchtower/Chart.yaml
+++ b/charts/watchtower/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Watchtower
 name: watchtower
-version: 1.3.0
+version: 1.3.1
 sources:
   - https://github.com/NCCloud/watchtower
 maintainers:

--- a/charts/watchtower/templates/prometheusrule.yaml
+++ b/charts/watchtower/templates/prometheusrule.yaml
@@ -26,10 +26,19 @@ spec:
     {{- end }}
     {{- if .Values.prometheusRule.builtInRules.down }}
     - alert: WatchtowerDown
-      expr: absent(up{job="watchtower"})
+      expr: count by(cluster, job, service) (up{job="watchtower"} == 0) / count by(cluster, job, service) (up{job="watchtower"}) or absent(up{job="watchtower"})
       for: 10m
       labels:
         severity: warning-devops
+      annotations:
+        dashboard: watchtower-operator
+        description: Watchtower has disappeared from Prometheus target discovery.
+        summary: Watchtower is down.
+    - alert: WatchtowerDown
+      expr: count by(cluster, job, service) (up{job="watchtower"} == 0) / count by(cluster, job, service) (up{job="watchtower"}) or absent(up{job="watchtower"})
+      for: 30m
+      labels:
+        severity: critical-devops
       annotations:
         dashboard: watchtower-operator
         description: Watchtower has disappeared from Prometheus target discovery.


### PR DESCRIPTION
- update the query for the `WatchtowerDown` alert to catch more cases
- add a critical alert with the `for: 30m` threshold
