### PR TITLE
Add wireguard-operator Helm chart

### DIFF
--- a/charts/wireguard-operator/.helmignore
+++ b/charts/wireguard-operator/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/wireguard-operator/Chart.yaml
+++ b/charts/wireguard-operator/Chart.yaml
@@ -1,0 +1,10 @@
+apiVersion: v2
+name: wireguard-operator
+description: Wireguard kubernetes operator
+type: application
+version: 0.1.0
+appVersion: "v2.8.0"
+keywords:
+  - wireguard
+  - operator
+  - kubernetes

--- a/charts/wireguard-operator/Chart.yaml
+++ b/charts/wireguard-operator/Chart.yaml
@@ -8,3 +8,8 @@ keywords:
   - wireguard
   - operator
   - kubernetes
+sources:
+  - https://github.com/nccloud/wireguard-operator
+maintainers:
+  - name: nocturo
+    email: nemanja.zeljkovic@namecheap.com

--- a/charts/wireguard-operator/crds/wireguardpeers.vpn.wireguard-operator.io.yaml
+++ b/charts/wireguard-operator/crds/wireguardpeers.vpn.wireguard-operator.io.yaml
@@ -1,0 +1,246 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.5
+  name: wireguardpeers.vpn.wireguard-operator.io
+spec:
+  group: vpn.wireguard-operator.io
+  names:
+    kind: WireguardPeer
+    listKind: WireguardPeerList
+    plural: wireguardpeers
+    singular: wireguardpeer
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: WireguardPeer is the Schema for the wireguardpeers API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: The desired state of the peer.
+            properties:
+              address:
+                description: |-
+                  INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
+                  Important: Run "make" to regenerate code after modifying this file
+                  The address of the peer.
+                type: string
+              addressV6:
+                description: The IPv6 address of the peer.
+                type: string
+              allowedIPs:
+                description: The AllowedIPs of the peer.
+                type: string
+              disabled:
+                description: Set to true to temporarily disable the peer.
+                type: boolean
+              dns:
+                description: The DNS configuration for the peer.
+                type: string
+              dnsSearchDomain:
+                description: The DNS search domain(s) for the peer.
+                type: string
+              downloadSpeed:
+                properties:
+                  config:
+                    type: integer
+                  unit:
+                    enum:
+                    - mbps
+                    - kbps
+                    type: string
+                type: object
+              egressNetworkPolicies:
+                description: Egress network policies for the peer.
+                items:
+                  properties:
+                    action:
+                      description: Specifies the action to take when outgoing traffic
+                        from a Wireguard peer matches the policy. This could be 'Accept'
+                        or 'Reject'.
+                      enum:
+                      - ACCEPT
+                      - REJECT
+                      - Accept
+                      - Reject
+                      type: string
+                    protocol:
+                      description: Specifies the protocol to match for this policy.
+                        This could be TCP, UDP, or ICMP.
+                      enum:
+                      - TCP
+                      - UDP
+                      - ICMP
+                      type: string
+                    to:
+                      description: A struct that specifies the destination address
+                        and port for the traffic. This could include IP addresses
+                        or hostnames, as well as specific port numbers or port ranges.
+                      properties:
+                        ip:
+                          description: A string field that specifies the destination
+                            IP address for traffic that matches the policy.
+                          type: string
+                        port:
+                          description: An integer field that specifies the destination
+                            port number for traffic that matches the policy.
+                          format: int32
+                          type: integer
+                      type: object
+                  type: object
+                type: array
+              privateKeyRef:
+                description: The private key of the peer
+                properties:
+                  secretKeyRef:
+                    description: SecretKeySelector selects a key of a Secret.
+                    properties:
+                      key:
+                        description: The key of the secret to select from.  Must be
+                          a valid secret key.
+                        type: string
+                      name:
+                        default: ""
+                        description: |-
+                          Name of the referent.
+                          This field is effectively required, but due to backwards compatibility is
+                          allowed to be empty. Instances of this type with an empty value here are
+                          almost certainly wrong.
+                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                        type: string
+                      optional:
+                        description: Specify whether the Secret or its key must be
+                          defined
+                        type: boolean
+                    required:
+                    - key
+                    type: object
+                    x-kubernetes-map-type: atomic
+                required:
+                - secretKeyRef
+                type: object
+              publicKey:
+                description: The key used by the peer to authenticate with the wg
+                  server.
+                type: string
+              uploadSpeed:
+                properties:
+                  config:
+                    type: integer
+                  unit:
+                    enum:
+                    - mbps
+                    - kbps
+                    type: string
+                type: object
+              wireguardRef:
+                description: The name of the Wireguard instance in k8s that the peer
+                  belongs to. The wg instance should be in the same namespace as the
+                  peer.
+                minLength: 1
+                type: string
+            required:
+            - wireguardRef
+            type: object
+          status:
+            description: A field that defines the observed state of the Wireguard
+              peer. This includes fields like the current configuration and status
+              of the peer.
+            properties:
+              conditions:
+                description: Conditions represent the latest available observations
+                  of the WireguardPeer's state.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              message:
+                description: A string field that provides additional information about
+                  the status of the Wireguard peer. This could include error messages
+                  or other information that helps to diagnose issues with the peer.
+                type: string
+              status:
+                description: |-
+                  INSERT ADDITIONAL STATUS FIELD - define observed state of cluster
+                  Important: Run "make" to regenerate code after modifying this file
+                  A string field that represents the current status of the Wireguard peer. This could include values like ready, pending, or error.
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/charts/wireguard-operator/crds/wireguards.vpn.wireguard-operator.io.yaml
+++ b/charts/wireguard-operator/crds/wireguards.vpn.wireguard-operator.io.yaml
@@ -1,0 +1,337 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.5
+  name: wireguards.vpn.wireguard-operator.io
+spec:
+  group: vpn.wireguard-operator.io
+  names:
+    kind: Wireguard
+    listKind: WireguardList
+    plural: wireguards
+    singular: wireguard
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: Wireguard is the Schema for the wireguards API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: WireguardSpec defines the desired state of Wireguard
+            properties:
+              address:
+                description: A string field that specifies the address for the Wireguard
+                  VPN server. This is the public IP address or hostname that peers
+                  will use to connect to the VPN.
+                type: string
+              agent:
+                description: WireguardPodSpec defines spec for respective containers
+                  created for Wireguard
+                properties:
+                  resources:
+                    description: ResourceRequirements describes the compute resource
+                      requirements.
+                    properties:
+                      claims:
+                        description: |-
+                          Claims lists the names of resources, defined in spec.resourceClaims,
+                          that are used by this container.
+
+                          This is an alpha field and requires enabling the
+                          DynamicResourceAllocation feature gate.
+
+                          This field is immutable. It can only be set for containers.
+                        items:
+                          description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                          properties:
+                            name:
+                              description: |-
+                                Name must match the name of one entry in pod.spec.resourceClaims of
+                                the Pod where this field is used. It makes that resource available
+                                inside a container.
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: |-
+                          Limits describes the maximum amount of compute resources allowed.
+                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: |-
+                          Requests describes the minimum amount of compute resources required.
+                          If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                          otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                    type: object
+                type: object
+              dns:
+                description: A string field that specifies the DNS server(s) to be
+                  used by the peers.
+                type: string
+              dnsSearchDomain:
+                description: A string field that specifies the DNS search domain(s)
+                  to be used by the peers.
+                type: string
+              enableIpForwardOnPodInit:
+                description: A boolean field that specifies whether IP forwarding
+                  should be enabled on the Wireguard VPN pod at startup. This can
+                  be useful to enable if the peers are having problems with sending
+                  traffic to the internet.
+                type: boolean
+              ipv6Only:
+                description: |-
+                  IPv6Only indicates that only IPv6 connectivity should be configured for peers.
+                  When true and PeerCIDRv6 is set, the operator will not allocate new IPv4 peer addresses
+                  or configure IPv4 routing/NAT for this instance.
+                type: boolean
+              metric:
+                description: WireguardPodSpec defines spec for respective containers
+                  created for Wireguard
+                properties:
+                  resources:
+                    description: ResourceRequirements describes the compute resource
+                      requirements.
+                    properties:
+                      claims:
+                        description: |-
+                          Claims lists the names of resources, defined in spec.resourceClaims,
+                          that are used by this container.
+
+                          This is an alpha field and requires enabling the
+                          DynamicResourceAllocation feature gate.
+
+                          This field is immutable. It can only be set for containers.
+                        items:
+                          description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                          properties:
+                            name:
+                              description: |-
+                                Name must match the name of one entry in pod.spec.resourceClaims of
+                                the Pod where this field is used. It makes that resource available
+                                inside a container.
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: |-
+                          Limits describes the maximum amount of compute resources allowed.
+                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: |-
+                          Requests describes the minimum amount of compute resources required.
+                          If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                          otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                    type: object
+                type: object
+              mtu:
+                description: A string field that specifies the maximum transmission
+                  unit (MTU) size for Wireguard packets for all peers.
+                type: string
+              nodeSelector:
+                additionalProperties:
+                  type: string
+                type: object
+              peerCIDR:
+                description: |-
+                  PeerCIDR is the IPv4 CIDR range from which Wireguard peer addresses will be allocated.
+                  If omitted (and IPv6Only is false), the operator will default to 10.8.0.0/24.
+                type: string
+              peerCIDRv6:
+                description: |-
+                  PeerCIDRv6 is the IPv6 CIDR range from which Wireguard peer IPv6 addresses will be allocated.
+                  When set, IPv6 support is enabled for this Wireguard instance.
+                type: string
+              port:
+                description: A field that specifies the value to use for a nodePort
+                  ServiceType
+                format: int32
+                type: integer
+              serviceAnnotations:
+                additionalProperties:
+                  type: string
+                description: A map of key value strings for service annotations
+                type: object
+              serviceType:
+                description: A field that specifies the type of Kubernetes service
+                  that should be used for the Wireguard VPN. This could be ClusterIP,
+                  NodePort or LoadBalancer, depending on the needs of the deployment.
+                type: string
+              useWgUserspaceImplementation:
+                description: A boolean field that specifies whether to use the userspace
+                  implementation of Wireguard instead of the kernel one.
+                type: boolean
+            type: object
+          status:
+            description: WireguardStatus defines the observed state of Wireguard
+            properties:
+              address:
+                description: A string field that specifies the address for the Wireguard
+                  VPN server that is currently being used.
+                type: string
+              conditions:
+                description: Conditions represent the latest available observations
+                  of the Wireguard's state.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              dns:
+                type: string
+              message:
+                description: A string field that provides additional information about
+                  the status of Wireguard. This could include error messages or other
+                  information that helps to diagnose issues with the wg instance.
+                type: string
+              port:
+                description: A string field that specifies the port for the Wireguard
+                  VPN server that is currently being used.
+                type: string
+              resources:
+                description: Resource-level status information for associated Kubernetes
+                  resources.
+                items:
+                  description: Resource describes the observed state of a related
+                    Kubernetes resource.
+                  properties:
+                    image:
+                      description: The container image when applicable (e.g., for
+                        Deployments).
+                      type: string
+                    name:
+                      description: The resource name (e.g., my-wg-dep, my-wg-svc).
+                      type: string
+                    status:
+                      description: A short status string (e.g., Ready, Pending, Error).
+                      type: string
+                    type:
+                      description: The resource type (e.g., Deployment, Service, ConfigMap,
+                        Secret).
+                      type: string
+                  type: object
+                type: array
+              status:
+                description: A string field that represents the current status of
+                  Wireguard. This could include values like ready, pending, or error.
+                type: string
+              uniqueIdentifier:
+                description: A stable identifier for the Wireguard instance (e.g.,
+                  server public key).
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/charts/wireguard-operator/templates/_helpers.tpl
+++ b/charts/wireguard-operator/templates/_helpers.tpl
@@ -1,0 +1,65 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "wireguard-operator.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "wireguard-operator.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "wireguard-operator.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "wireguard-operator.labels" -}}
+helm.sh/chart: {{ include "wireguard-operator.chart" . }}
+{{ include "wireguard-operator.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "wireguard-operator.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "wireguard-operator.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "wireguard-operator.serviceAccountName" -}}
+{{- $default := (include "wireguard-operator.fullname" .) }}
+{{- with .Values.serviceAccount }}
+{{- if .create }}
+{{- default $default .name }}
+{{- else }}
+{{- default "default" .name }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/wireguard-operator/templates/deployment.yaml
+++ b/charts/wireguard-operator/templates/deployment.yaml
@@ -32,14 +32,8 @@ spec:
         - --metrics-bind-address=:8080
         - --leader-elect
         - --agent-image={{ .Values.agentImage.repository }}:{{ .Values.agentImage.tag | default .Chart.AppVersion }}
-        {{- range $key, $value := .Values.extraArgs }}
-        {{- if kindIs "slice" $value }}
-        {{- range $v := $value }}
-        - --{{ $key }}={{ $v }}
-        {{- end }}
-        {{- else }}
-        - --{{ $key }}={{ $value }}
-        {{- end }}
+        {{- range .Values.extraArgs }}
+        - {{ . }}
         {{- end }}
         command:
         - /manager

--- a/charts/wireguard-operator/templates/deployment.yaml
+++ b/charts/wireguard-operator/templates/deployment.yaml
@@ -1,0 +1,83 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "wireguard-operator.fullname" . }}-controller-manager
+  labels:
+    control-plane: controller-manager
+  {{- include "wireguard-operator.labels" . | nindent 4 }}
+  {{- with .Values.annotations }}
+  annotations: {{ toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      control-plane: controller-manager
+    {{- include "wireguard-operator.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.annotations }}
+      annotations: {{ toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        control-plane: controller-manager
+      {{- include "wireguard-operator.selectorLabels" . | nindent 8 }}
+      annotations:
+        kubectl.kubernetes.io/default-container: manager
+    spec:
+      containers:
+      - args:
+        - --zap-log-level={{ .Values.logLevel }}
+        - --health-probe-bind-address=:8081
+        - --metrics-bind-address=:8080
+        - --leader-elect
+        - --agent-image={{ .Values.agentImage.repository }}:{{ .Values.agentImage.tag | default .Chart.AppVersion }}
+        {{- range $key, $value := .Values.extraArgs }}
+        {{- if kindIs "slice" $value }}
+        {{- range $v := $value }}
+        - --{{ $key }}={{ $v }}
+        {{- end }}
+        {{- else }}
+        - --{{ $key }}={{ $value }}
+        {{- end }}
+        {{- end }}
+        command:
+        - /manager
+        env:
+        {{- with .Values.env }}
+        {{ toYaml . }}
+        {{- end }}
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        image: {{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8081
+          initialDelaySeconds: 15
+          periodSeconds: 20
+        name: manager
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: 8081
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        resources: {{- toYaml .Values.resources | nindent 10 }}
+        {{- with .Values.securityContext }}
+        securityContext: {{- toYaml . | nindent 10 }}
+        {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector: {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.podSecurityContext }}
+      securityContext: {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "wireguard-operator.serviceAccountName" . }}-controller-manager
+      terminationGracePeriodSeconds: 10
+      {{- with .Values.tolerations }}
+      tolerations: {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/wireguard-operator/templates/leader-election-rbac.yaml
+++ b/charts/wireguard-operator/templates/leader-election-rbac.yaml
@@ -1,0 +1,55 @@
+{{- if .Values.rbac.create }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "wireguard-operator.fullname" . }}-leader-election-role
+  labels:
+  {{- include "wireguard-operator.labels" . | nindent 4 }}
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "wireguard-operator.fullname" . }}-leader-election-rolebinding
+  labels:
+  {{- include "wireguard-operator.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "wireguard-operator.fullname" . }}-leader-election-role
+subjects:
+- kind: ServiceAccount
+  name: {{ include "wireguard-operator.serviceAccountName" . }}-controller-manager
+  namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/charts/wireguard-operator/templates/manager-rbac.yaml
+++ b/charts/wireguard-operator/templates/manager-rbac.yaml
@@ -1,0 +1,100 @@
+{{- if .Values.rbac.create }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "wireguard-operator.fullname" . }}-manager-role
+  labels:
+  {{- include "wireguard-operator.labels" . | nindent 4 }}
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - pods
+  - secrets
+  - services
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  - pods
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create
+- apiGroups:
+  - vpn.wireguard-operator.io
+  resources:
+  - wireguardpeers
+  - wireguards
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - vpn.wireguard-operator.io
+  resources:
+  - wireguardpeers/finalizers
+  - wireguards/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - vpn.wireguard-operator.io
+  resources:
+  - wireguardpeers/status
+  - wireguards/status
+  verbs:
+  - get
+  - patch
+  - update
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "wireguard-operator.fullname" . }}-manager-rolebinding
+  labels:
+  {{- include "wireguard-operator.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "wireguard-operator.fullname" . }}-manager-role
+subjects:
+- kind: ServiceAccount
+  name: {{ include "wireguard-operator.serviceAccountName" . }}-controller-manager
+  namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/charts/wireguard-operator/templates/metrics-reader-rbac.yaml
+++ b/charts/wireguard-operator/templates/metrics-reader-rbac.yaml
@@ -1,0 +1,33 @@
+{{ if .Values.rbac.create }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "wireguard-operator.fullname" . }}-metrics-reader
+  labels:
+  {{- include "wireguard-operator.labels" . | nindent 4 }}
+rules:
+- nonResourceURLs:
+  - /metrics
+  verbs:
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "wireguard-operator.fullname" . }}-metrics-reader
+  labels:
+  {{- include "wireguard-operator.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "wireguard-operator.fullname" . }}-metrics-reader
+subjects:
+- kind: ServiceAccount
+  name: {{ include "wireguard-operator.serviceAccountName" . }}-metrics-reader
+  namespace: {{ .Release.Namespace }}
+{{- if .Values.serviceMonitor.enabled }}
+- kind: ServiceAccount
+  name: {{ .Values.serviceMonitor.prometheus.serviceAccountName }}
+  namespace: {{ .Values.serviceMonitor.prometheus.namespace }}
+{{- end }}
+{{- end }}

--- a/charts/wireguard-operator/templates/metrics-service.yaml
+++ b/charts/wireguard-operator/templates/metrics-service.yaml
@@ -1,0 +1,18 @@
+{{ if .Values.service.create }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "wireguard-operator.fullname" . }}-controller-manager-metrics-service
+  labels:
+    control-plane: controller-manager
+  {{- include "wireguard-operator.labels" . | nindent 4 }}
+spec:
+  selector:
+    control-plane: controller-manager
+    {{- include "wireguard-operator.selectorLabels" . | nindent 4 }}
+  ports:
+  - name: metrics
+    port: 8080
+    targetPort: 8080
+    protocol: TCP
+{{- end }}

--- a/charts/wireguard-operator/templates/metrics-servicemonitor.yaml
+++ b/charts/wireguard-operator/templates/metrics-servicemonitor.yaml
@@ -1,0 +1,33 @@
+{{- if .Values.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "wireguard-operator.fullname" . }}-controller-manager-metrics-monitor
+  labels:
+    control-plane: controller-manager
+    {{- include "wireguard-operator.labels" . | nindent 4 }}
+  {{- with .Values.serviceMonitor.annotations }}
+  annotations:
+{{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  endpoints:
+    - path: /metrics
+      port: metrics
+      scheme: http
+      bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+      {{- with .Values.serviceMonitor.interval }}
+      interval: {{ . }}
+      {{- end }}
+      {{- with .Values.serviceMonitor.scrapeTimeout }}
+      scrapeTimeout: {{ . }}
+      {{- end }}
+      {{- with .Values.serviceMonitor.relabelings }}
+      relabelings:
+{{- toYaml . | nindent 8 }}
+      {{- end }}
+  selector:
+    matchLabels:
+      control-plane: controller-manager
+      {{- include "wireguard-operator.selectorLabels" . | nindent 6 }}
+{{- end }}

--- a/charts/wireguard-operator/templates/serviceaccount.yaml
+++ b/charts/wireguard-operator/templates/serviceaccount.yaml
@@ -1,0 +1,25 @@
+{{ if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "wireguard-operator.fullname" . }}-controller-manager
+  labels:
+  {{- include "wireguard-operator.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "wireguard-operator.fullname" . }}-metrics-reader
+  labels:
+  {{- include "wireguard-operator.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
+{{- end }}

--- a/charts/wireguard-operator/values.yaml
+++ b/charts/wireguard-operator/values.yaml
@@ -1,9 +1,11 @@
 image:
   repository: ghcr.io/nccloud/wireguard-operator/manager
+  tag: ""
   pullPolicy: IfNotPresent
 
 agentImage:
   repository: ghcr.io/nccloud/wireguard-operator/agent
+  tag: ""
 
 replicaCount: 1
 

--- a/charts/wireguard-operator/values.yaml
+++ b/charts/wireguard-operator/values.yaml
@@ -1,0 +1,71 @@
+image:
+  repository: ghcr.io/nccloud/wireguard-operator/manager
+  pullPolicy: IfNotPresent
+
+agentImage:
+  repository: ghcr.io/nccloud/wireguard-operator/agent
+
+replicaCount: 1
+
+imagePullSecrets: []
+
+nameOverride: ""
+
+fullnameOverride: ""
+
+logLevel: "info"
+
+rbac:
+  create: true
+
+annotations: {}
+
+podSecurityContext:
+  fsGroup: 65534
+  runAsNonRoot: true
+
+securityContext:
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop:
+      - ALL
+  readOnlyRootFilesystem: true
+  runAsGroup: 65534
+  runAsNonRoot: false
+  runAsUser: 65534
+
+serviceAccount:
+  create: true
+  name: ""
+  automountServiceAccountToken: true
+
+service:
+  create: true
+
+resources:
+  limits:
+    cpu: 500m
+    memory: 128Mi
+  requests:
+    cpu: 10m
+    memory: 64Mi
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}
+
+extraArgs: {}
+
+env: []
+
+serviceMonitor:
+  enabled: false
+  interval: ""
+  scrapeTimeout: ""
+  relabelings: []
+  prometheus:
+    # -- specify correct Prometheus ServiceAccount that we add to CRB for scraping /metrics for the operator
+    serviceAccountName: prometheus-k8s
+    namespace: monitoring

--- a/charts/wireguard-operator/values.yaml
+++ b/charts/wireguard-operator/values.yaml
@@ -58,7 +58,10 @@ tolerations: []
 
 affinity: {}
 
-extraArgs: {}
+# -- pass extra arguments to the controller container. One list argument per line
+# extraArgs:
+#   - --agent-image-pull-policy=Always
+extraArgs: []
 
 env: []
 


### PR DESCRIPTION
Adds a `wireguard-operator` Helm chart that manages our custom fork of [wireguard-operator](https://github.com/nccloud/wireguard-operator).