### PR TITLE
[CU-86c7mz3q6] Update Chrony exporter alerts

### DIFF
--- a/charts/chrony-exporter/Chart.yaml
+++ b/charts/chrony-exporter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: chrony-exporter
 description: Helm chart for chrony-exporter
 type: application
-version: 0.0.1
+version: 0.1.0
 appVersion: "v0.12.3"
 sources:
   - https://github.com/SuperQ/chrony_exporter

--- a/charts/chrony-exporter/templates/prometheusrule.yaml
+++ b/charts/chrony-exporter/templates/prometheusrule.yaml
@@ -15,7 +15,7 @@ spec:
             +
             chrony_tracking_root_dispersion_seconds
             +
-            (0.5 * chrony_tracking_root_delay_seconds) > 0.05
+            (0.5 * chrony_tracking_root_delay_seconds) > 0.25
           for: 10m
           labels:
             severity: warning
@@ -32,15 +32,6 @@ spec:
             dashboard: chrony-exporter?var-node={{ `{{ $labels.nodename }}` }}
             summary: 'Chrony time offset elevated on {{ `{{ $labels.nodename }}` }}'
             description: 'System time offset is {{ `{{ $value }}` }}s on {{ `{{ $labels.nodename }}` }}'
-        - alert: ChronyNoReachableServers
-          expr: chrony_sources_reachability_success == 0
-          for: 10m
-          labels:
-            severity: warning
-          annotations:
-            dashboard: chrony-exporter?var-node={{ `{{ $labels.nodename }}` }}
-            summary: 'No reachable NTP sources on {{ `{{ $labels.nodename }}` }}'
-            description: 'Chrony has no reachable NTP sources on {{ `{{ $labels.nodename }}` }}. Time synchronization will fail'
         - alert: ChronyHighRootDispersion
           expr: chrony_tracking_root_dispersion_seconds > 0.1
           for: 15m


### PR DESCRIPTION
- increases threshold for `ChronyNoReachableServers` alert from 50ms to 250ms
- removes `ChronyNoReachableServers` as some NTP servers are not available from time to time and this alert is flapping