### PR TITLE
Update harbor-vulnerabilities-exporter chart

### DIFF
--- a/charts/harbor-vulnerabilities-exporter/Chart.yaml
+++ b/charts/harbor-vulnerabilities-exporter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: harbor-vulnerabilities-exporter
 description: A Helm chart for showing vulnerabilities information in images stored in Harbor
-version: 1.0.4
+version: 1.1.0
 sources:
   - https://github.com/NCCloud/harbor-vulnerabilities-exporter
 maintainers:

--- a/charts/harbor-vulnerabilities-exporter/templates/deployment.yaml
+++ b/charts/harbor-vulnerabilities-exporter/templates/deployment.yaml
@@ -27,13 +27,13 @@ spec:
             - name: HARBOR_USERNAME
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Values.existingSecret | default (include "harbor-vulnerabilities-exporter.name" .) }}
-                  key: username
+                  name: {{ .Values.existingSecret.secretName | default (include "harbor-vulnerabilities-exporter.name" .) }}
+                  key: {{ .Values.existingSecret.usernameKey }}
             - name: HARBOR_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Values.existingSecret | default (include "harbor-vulnerabilities-exporter.name" .) }}
-                  key: password
+                  name: {{ .Values.existingSecret.secretName | default (include "harbor-vulnerabilities-exporter.name" .) }}
+                  key: {{ .Values.existingSecret.passwordKey }}
             - name: EXPORTER_PORT
               value: "{{ .Values.exporterPort }}"
             - name: IGNORE_REPOSITORIES

--- a/charts/harbor-vulnerabilities-exporter/templates/deployment.yaml
+++ b/charts/harbor-vulnerabilities-exporter/templates/deployment.yaml
@@ -18,18 +18,42 @@ spec:
       containers:
         - name: harbor-vulnerabilities-exporter
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - containerPort: {{ .Values.exporterPort }}
           env:
             - name: HARBOR_API_URL
               value: "{{ .Values.harborApiUrl }}"
             - name: HARBOR_USERNAME
-              value: "{{ .Values.harborUsername }}"
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.existingSecret | default (include "harbor-vulnerabilities-exporter.name" .) }}
+                  key: username
             - name: HARBOR_PASSWORD
-              value: "{{ .Values.harborPassword }}"
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.existingSecret | default (include "harbor-vulnerabilities-exporter.name" .) }}
+                  key: password
             - name: EXPORTER_PORT
               value: "{{ .Values.exporterPort }}"
-            - name: THREADS
-              value: "{{ .Values.threadCount }}"
             - name: IGNORE_REPOSITORIES
               value: '{{ join "," .Values.ignoreRepositories }}'
+            {{- with .Values.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          livenessProbe:
+            httpGet:
+              path: /metrics
+              port: {{ .Values.exporterPort }}
+            initialDelaySeconds: 10
+            periodSeconds: 30
+          readinessProbe:
+            httpGet:
+              path: /metrics
+              port: {{ .Values.exporterPort }}
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          {{- with .Values.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}

--- a/charts/harbor-vulnerabilities-exporter/templates/secret.yaml
+++ b/charts/harbor-vulnerabilities-exporter/templates/secret.yaml
@@ -1,4 +1,4 @@
-{{- if not .Values.existingSecret }}
+{{- if not .Values.existingSecret.secretName }}
 ---
 apiVersion: v1
 kind: Secret
@@ -8,6 +8,6 @@ metadata:
     {{- include "harbor-vulnerabilities-exporter.labels" . | nindent 4 }}
 type: Opaque
 stringData:
-  username: {{ .Values.harborUsername | quote }}
-  password: {{ .Values.harborPassword | quote }}
+  {{ .Values.existingSecret.usernameKey }}: {{ .Values.harborUsername | quote }}
+  {{ .Values.existingSecret.passwordKey }}: {{ .Values.harborPassword | quote }}
 {{- end }}

--- a/charts/harbor-vulnerabilities-exporter/templates/secret.yaml
+++ b/charts/harbor-vulnerabilities-exporter/templates/secret.yaml
@@ -1,0 +1,13 @@
+{{- if not .Values.existingSecret }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "harbor-vulnerabilities-exporter.name" . }}
+  labels:
+    {{- include "harbor-vulnerabilities-exporter.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  username: {{ .Values.harborUsername | quote }}
+  password: {{ .Values.harborPassword | quote }}
+{{- end }}

--- a/charts/harbor-vulnerabilities-exporter/values.yaml
+++ b/charts/harbor-vulnerabilities-exporter/values.yaml
@@ -1,7 +1,5 @@
 ---
-# -- override the chart name
 # nameOverride: ""
-# -- fully override the resource name
 # fullnameOverride: ""
 
 replicas: 1

--- a/charts/harbor-vulnerabilities-exporter/values.yaml
+++ b/charts/harbor-vulnerabilities-exporter/values.yaml
@@ -11,12 +11,15 @@ exporterPort: 8000
 # - project/repo1
 # - project/repo2
 
-# -- name of an existing Secret with username and password keys; if set, harborUsername and harborPassword are ignored
-existingSecret: ""
+# -- existing Secret with harbor credentials; if secretName is set, harborUsername and harborPassword are ignored
+existingSecret:
+  secretName: ""
+  usernameKey: username
+  passwordKey: password
 
 # -- script won't use credentials if values are empty read-only user should be enough
-harborUsername: ''
-harborPassword: ''
+harborUsername: ""
+harborPassword: ""
 
 # -- additional environment variables to pass to the container
 extraEnv: []

--- a/charts/harbor-vulnerabilities-exporter/values.yaml
+++ b/charts/harbor-vulnerabilities-exporter/values.yaml
@@ -1,22 +1,47 @@
 ---
+# -- override the chart name
+# nameOverride: ""
+# -- fully override the resource name
+# fullnameOverride: ""
+
 replicas: 1
 harborApiUrl: 'http://harbor-harbor-harbor-core.harbor/api/v2.0'
 exporterPort: 8000
-# -- number of threads for exporter script to call Harbor API
-threadCount: 5
 
 # -- list of project/repositories to ignore (won't create a metric in prometheus)
 # ignoreRepositories:
 # - project/repo1
 # - project/repo2
 
+# -- name of an existing Secret with username and password keys; if set, harborUsername and harborPassword are ignored
+existingSecret: ""
+
 # -- script won't use credentials if values are empty read-only user should be enough
 harborUsername: ''
 harborPassword: ''
 
+# -- additional environment variables to pass to the container
+extraEnv: []
+# -- number of threads for exporter script to call Harbor API
+# - name: THREADS
+#   value: "5"
+# -- maximum number of characters to store in the description label, 0 means no limit
+# - name: DESCRIPTION_MAX_LENGTH
+#   value: "0"
+
 image:
   repository: ghcr.io/nccloud/harbor-vulnerabilities-exporter
   tag: latest
+  pullPolicy: IfNotPresent
+
+# -- resource requests and limits for the exporter container
+resources: {}
+#  limits:
+#    cpu: 200m
+#    memory: 128Mi
+#  requests:
+#    cpu: 100m
+#    memory: 64Mi
 
 serviceMonitor:
   # -- serviceMonitor can be disabled if needed

--- a/charts/harbor-vulnerabilities-exporter/values.yaml
+++ b/charts/harbor-vulnerabilities-exporter/values.yaml
@@ -22,10 +22,10 @@ harborPassword: ''
 
 # -- additional environment variables to pass to the container
 extraEnv: []
-# -- number of threads for exporter script to call Harbor API
+# -- number of threads for exporter script to call Harbor API, 5 by default
 # - name: THREADS
 #   value: "5"
-# -- maximum number of characters to store in the description label, 0 means no limit
+# -- maximum number of characters to store in the description label, 0 by default means no limit
 # - name: DESCRIPTION_MAX_LENGTH
 #   value: "0"
 


### PR DESCRIPTION
* add ability to specify resources limits, livenessProbe and readinessProbe, imagePullPolicy
* harbor username and password will be taken from secret now
* user may specify existingSecret now
* added ability to specify additional env variables via extraEnv
* removed THREADS varible, it can be specified via extraEnv if needed (exporter script will set 5 threads by default)