### PR TITLE
Fix selectorLabels in harbor-vulnerabilities-exporter deployment template

### DIFF
--- a/charts/harbor-vulnerabilities-exporter/Chart.yaml
+++ b/charts/harbor-vulnerabilities-exporter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: harbor-vulnerabilities-exporter
 description: A Helm chart for showing vulnerabilities information in images stored in Harbor
-version: 1.1.0
+version: 1.1.1
 sources:
   - https://github.com/NCCloud/harbor-vulnerabilities-exporter
 maintainers:

--- a/charts/harbor-vulnerabilities-exporter/templates/_helpers.tpl
+++ b/charts/harbor-vulnerabilities-exporter/templates/_helpers.tpl
@@ -35,11 +35,18 @@ Create chart name and version as used by the chart label.
 Common labels
 */}}
 {{- define "harbor-vulnerabilities-exporter.labels" -}}
-app.kubernetes.io/name: {{ include "harbor-vulnerabilities-exporter.name" . }}
 helm.sh/chart: {{ include "harbor-vulnerabilities-exporter.chart" . }}
-app.kubernetes.io/instance: {{ .Release.Name }}
+{{ include "harbor-vulnerabilities-exporter.selectorLabels" . }}
 {{- if .Chart.AppVersion }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
+{{/*
+Selector labels
+*/}}
+{{- define "harbor-vulnerabilities-exporter.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "harbor-vulnerabilities-exporter.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end -}}

--- a/charts/harbor-vulnerabilities-exporter/templates/deployment.yaml
+++ b/charts/harbor-vulnerabilities-exporter/templates/deployment.yaml
@@ -9,7 +9,7 @@ spec:
   replicas: {{ .Values.replicas }}
   selector:
     matchLabels:
-      {{- include "harbor-vulnerabilities-exporter.labels" . | nindent 6 }}
+      {{- include "harbor-vulnerabilities-exporter.selectorLabels" . | nindent 6 }}
   template:
     metadata:
       labels:


### PR DESCRIPTION
* matchLabels shouldn't rely on dymanic labels like `helm.sh/chart`. That's why adding `harbor-vulnerabilities-exporter.selectorLabels` to avoid problems.