### PR TITLE
[CU-86c9xx61a] Update Zeropod servicemonitor

### DIFF
--- a/charts/zeropod/Chart.yaml
+++ b/charts/zeropod/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: zeropod
 description: Kubernetes runtime for scaling containers to zero after a certain amount of time of the last TCP connection using CRIU checkpointing
 type: application
-version: 0.1.1
+version: 0.1.2
 appVersion: v0.11.3
 sources:
   - https://github.com/ctrox/zeropod

--- a/charts/zeropod/templates/servicemonitor.yaml
+++ b/charts/zeropod/templates/servicemonitor.yaml
@@ -14,6 +14,10 @@ spec:
     {{- if .Values.manager.serviceMonitor.interval }}
     interval: {{ .Values.manager.serviceMonitor.interval }}
     {{- end }}
+    {{- if .Values.manager.serviceMonitor.metricRelabelings }}
+    metricRelabelings:
+      {{- toYaml .Values.manager.serviceMonitor.metricRelabelings | nindent 6 }}
+    {{- end }}
     {{- if .Values.manager.serviceMonitor.relabelings }}
     relabelings:
       {{- toYaml .Values.manager.serviceMonitor.relabelings | nindent 6 }}

--- a/charts/zeropod/templates/servicemonitor.yaml
+++ b/charts/zeropod/templates/servicemonitor.yaml
@@ -16,7 +16,7 @@ spec:
     {{- end }}
     {{- if .Values.manager.serviceMonitor.metricRelabelings }}
     metricRelabelings:
-      {{- toYaml .Values.manager.serviceMonitor.metricRelabelings | nindent 6 }}
+      {{- toYaml . | nindent 6 }}
     {{- end }}
     {{- if .Values.manager.serviceMonitor.relabelings }}
     relabelings:

--- a/charts/zeropod/templates/servicemonitor.yaml
+++ b/charts/zeropod/templates/servicemonitor.yaml
@@ -4,6 +4,9 @@ kind: ServiceMonitor
 metadata:
   labels:
     {{- include "zeropod.labels" . | nindent 4 }}
+    {{- with .Values.manager.serviceMonitor.additionalLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
   name: {{ include "zeropod.fullname" . }}
 spec:
   endpoints:

--- a/charts/zeropod/templates/servicemonitor.yaml
+++ b/charts/zeropod/templates/servicemonitor.yaml
@@ -20,7 +20,7 @@ spec:
     {{- end }}
     {{- if .Values.manager.serviceMonitor.relabelings }}
     relabelings:
-      {{- toYaml .Values.manager.serviceMonitor.relabelings | nindent 6 }}
+      {{- toYaml . | nindent 6 }}
     {{- end }}
     {{- if .Values.manager.serviceMonitor.scrapeTimeout }}
     scrapeTimeout: {{ .Values.manager.serviceMonitor.scrapeTimeout }}

--- a/charts/zeropod/values.yaml
+++ b/charts/zeropod/values.yaml
@@ -71,6 +71,8 @@ manager:
   serviceMonitor:
     # -- Enable the ServiceMonitor and headless Service
     enabled: false
+    # -- Extra labels added to the ServiceMonitor — useful for matching a specific Prometheus instance via serviceMonitorSelector
+    additionalLabels: {}
     # -- Prometheus scrape interval
     interval: 30s
     # -- Prometheus relabeling rules applied to scraped metrics

--- a/charts/zeropod/values.yaml
+++ b/charts/zeropod/values.yaml
@@ -75,6 +75,8 @@ manager:
     additionalLabels: {}
     # -- Prometheus scrape interval
     interval: 30s
+    # -- Prometheus metric relabeling rules applied to scraped metrics after they are received
+    metricRelabelings: []
     # -- Prometheus relabeling rules applied to scraped metrics
     relabelings: []
     # -- Prometheus scrape timeout


### PR DESCRIPTION
- add additionalLabels to servicemonitor so different Prometheus instances can be targeted in cluster;
- add metricRelabelings to servicemonitor;
- bump zeropod chart version