### PR TITLE
[CU-86caeu06d] Updating Chrony exporter alerts

### DIFF
--- a/charts/chrony-exporter/Chart.yaml
+++ b/charts/chrony-exporter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: chrony-exporter
 description: Helm chart for chrony-exporter
 type: application
-version: 0.1.0
+version: 0.2.0
 appVersion: "v0.12.3"
 sources:
   - https://github.com/SuperQ/chrony_exporter

--- a/charts/chrony-exporter/templates/prometheusrule.yaml
+++ b/charts/chrony-exporter/templates/prometheusrule.yaml
@@ -22,7 +22,7 @@ spec:
           annotations:
             dashboard: chrony-exporter?var-node={{ `{{ $labels.nodename }}` }}
             summary: Check chrony on the node
-            description: 'Clock error exceeds 50ms on {{ `{{ $labels.nodename }}` }}'
+            description: 'Clock error exceeds 250ms on {{ `{{ $labels.nodename }}` }}'
         - alert: ChronyLargeTimeOffset
           expr: abs(chrony_tracking_last_offset_seconds) > 0.5
           for: 10m
@@ -41,13 +41,4 @@ spec:
             dashboard: chrony-exporter?var-node={{ `{{ $labels.nodename }}` }}
             summary: 'High root dispersion on {{ `{{ $labels.nodename }}` }}'
             description: 'Root dispersion is {{ `{{ $value }}` }}s on {{ `{{ $labels.nodename }}` }}, indicating potential timing accuracy issues'
-        - alert: ChronyHighStratum
-          expr: chrony_tracking_stratum > 5
-          for: 15m
-          labels:
-            severity: warning
-          annotations:
-            dashboard: chrony-exporter?var-node={{ `{{ $labels.nodename }}` }}
-            summary: 'Chrony stratum too high on {{ `{{ $labels.nodename }}` }}'
-            description: 'Chrony stratum is {{ `{{ $value }}` }} on {{ `{{ $labels.nodename }}` }}. The server may be too far from authoritative time sources'
 {{- end }}


### PR DESCRIPTION
In this PR:
- Updated the threshold description of `ClockNotSynchronized` alert from 50ms to 250ms (the threshold itself was changed [previously](https://github.com/NCCloud/charts/pull/40)).
- Removed the `ChronyHighStratum` alert, since it appeared that stratum on its own may not be a reliable indicator of clock quality, and we have another alert, `ChronyHighRootDispersion,` which already covers the genuinely degraded-clock case. Related [thread](https://namecheapcloud.slack.com/archives/C06Q5N0EWF3/p1782818808024829?thread_ts=1782802410.189039&cid=C06Q5N0EWF3)